### PR TITLE
Force use of signed char in base64.cpp

### DIFF
--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -20,7 +20,7 @@
 using namespace std;
 
 static const string base64 = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-static const char base64_inverse[256] = {
+static const signed char base64_inverse[256] = {
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
 	-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, -1, -1, 63,


### PR DESCRIPTION
Fix #1.

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>